### PR TITLE
Create Env and test run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/env
+/venv
+requirements.txt
+
+**/__pycache__/
+
+data/

--- a/config/config.py
+++ b/config/config.py
@@ -15,10 +15,10 @@ def get_config(dir='config/config.yaml'):
         seq = [str(tmp) for tmp in seq]
         return ''.join(seq)
 
-    yaml.add_constructor('!join', join)
-    yaml.add_constructor('!concat', concat)
+    yaml.add_constructor('!join', join, Loader=yaml.SafeLoader)
+    yaml.add_constructor('!concat', concat, Loader=yaml.SafeLoader)
     with open(dir, 'r') as f:
-        cfg = yaml.load(f)
+        cfg = yaml.load(f, Loader=yaml.SafeLoader)
 
     check_dirs(cfg)
 

--- a/train.py
+++ b/train.py
@@ -50,7 +50,6 @@ def train_model(model, criterion, optimizer, scheduler, num_epochs=25, print_fre
         # Each epoch has a training and validation phase
         for phase in ['train', 'val']:
             if phase == 'train':
-                scheduler.step()
                 model.train()  # Set model to training mode
             else:
                 model.eval()  # Set model to evaluate mode
@@ -86,6 +85,10 @@ def train_model(model, criterion, optimizer, scheduler, num_epochs=25, print_fre
             if phase == 'val' and epoch_acc > best_acc:
                 best_acc = epoch_acc
                 best_model_wts = copy.deepcopy(model.state_dict())
+
+        # Scheduler step should be called after optimizer.step()
+        if phase == 'train':
+            scheduler.step()
 
         if epoch % print_freq == 0:
             print(f'Best val Acc: {best_acc:4f}')

--- a/utils/hypergraph_utils.py
+++ b/utils/hypergraph_utils.py
@@ -15,7 +15,7 @@ def Eu_dis(x):
                 D: Dimension of the feature
     :return: N X N distance matrix
     """
-    x = np.mat(x)
+    x = np.asmatrix(x)
     aa = np.sum(np.multiply(x, x), 1)
     ab = x * x.T
     dist_mat = aa + aa.T - 2 * ab
@@ -36,7 +36,8 @@ def feature_concat(*F_list, normal_col=False):
     """
     features = None
     for f in F_list:
-        if f is not None and f != []:
+        # if f is not None and f != []:
+        if f is not None and f.size > 0:
             # deal with the dimension that more than two
             if len(f.shape) > 2:
                 f = f.reshape(-1, f.shape[-1])
@@ -62,8 +63,10 @@ def hyperedge_concat(*H_list):
     :return: Fused hypergraph incidence matrix
     """
     H = None
+    # H_list contains possible [], np.ndarray, or None
     for h in H_list:
-        if h is not None and h != []:
+        # if h is not None and h != []:
+        if isinstance(h, np.ndarray) and h.size > 0:
             # for the first H appended to fused hypergraph incidence matrix
             if H is None:
                 H = h
@@ -110,10 +113,10 @@ def _generate_G_from_H(H, variable_weight=False):
     # the degree of the hyperedge
     DE = np.sum(H, axis=0)
 
-    invDE = np.mat(np.diag(np.power(DE, -1)))
-    DV2 = np.mat(np.diag(np.power(DV, -0.5)))
-    W = np.mat(np.diag(W))
-    H = np.mat(H)
+    invDE = np.asmatrix(np.diag(np.power(DE, -1)))
+    DV2 = np.asmatrix(np.diag(np.power(DV, -0.5)))
+    W = np.asmatrix(np.diag(W))
+    H = np.asmatrix(H)
     HT = H.T
 
     if variable_weight:


### PR DESCRIPTION
# Change
1. Change `scheduler.step()` based on current torch version. 
```
UserWarning: Detected call of `lr_scheduler.step()` before `optimizer.step()`. In PyTorch 1.1.0 and later, you should call them in the opposite order: `optimizer.step()` before `lr_scheduler.step()`.  Failure to do this will result in PyTorch skipping the first value of the learning rate schedule. See more details at https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate
```
2. Minor fixes for yaml and numpy versions.

# Test
`python3 train.py` successfully ran.